### PR TITLE
Release 0.37

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.37
+
+* Add NFSCACHE driver
+* Add support in NFSCACHE driver to create /tmp/<uuid> directories to run kerberos in docker as user
+* Add parameter lazyumount to pass --lazy to the umount command in NFSCACHE driver
+* Fix mount grep for similar mounts names

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION = 0.36
+VERSION = 0.37
 GO_FMT = gofmt -s -w -l .
 GO_XC = goxc -os="linux" -bc="linux,amd64,arm" -tasks-="rmbin"
 

--- a/netshare/drivers/cache.go
+++ b/netshare/drivers/cache.go
@@ -1,0 +1,174 @@
+package drivers
+
+import (
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strconv"
+	"sync"
+
+	"github.com/docker/go-plugins-helpers/volume"
+	log "github.com/sirupsen/logrus"
+)
+
+type cacheDriver struct {
+	root       string
+	mountm     *MountManager
+	m          *sync.Mutex
+	dirs       map[string]map[string]string
+	mountPoint string
+	state      string
+}
+
+func newCacheDriver(root string, mounts *MountManager, path string, state string) cacheDriver {
+	// Load state info
+	jsonData, _ := readState(state)
+	log.Printf("Json: %s", jsonData)
+
+	return cacheDriver{
+		root:       root,
+		mountm:     mounts,
+		m:          &sync.Mutex{},
+		dirs:       jsonData,
+		mountPoint: path,
+		state:      state,
+	}
+}
+
+func (c cacheDriver) Create(r *volume.CreateRequest) error {
+	log.Debugf("Entering Create: name: %s", r.Name)
+
+	c.m.Lock()
+	defer c.m.Unlock()
+
+	if _, err := strconv.Atoi(r.Name); err == nil {
+		u, err := user.LookupId(r.Name)
+		if err != nil {
+			return err
+		}
+
+		volumePath := filepath.Join(c.mountPoint, u.Uid)
+
+		// Create the volume if does not exist
+		if _, ok := c.dirs[u.Uid]; !ok {
+			// Create directory if does not exist and set permissions
+			log.Debugf("Create ccache directory: %s/%s", c.mountPoint, u.Uid)
+			if _, err := os.Stat(volumePath); os.IsNotExist(err) {
+				os.Mkdir(volumePath, 0700)
+				uid, _ := strconv.Atoi(u.Uid)
+				gid, _ := strconv.Atoi(u.Gid)
+				os.Chown(volumePath, uid, gid)
+			}
+			// Add the volume
+			c.dirs[u.Uid] = map[string]string{
+				"Path": volumePath,
+			}
+			writeState(c.state, c.dirs)
+		}
+	} else {
+		log.Debugf("Options %v", r.Options)
+		resName, resOpts := resolveName(r.Name)
+		if resOpts != nil {
+			// Check to make sure there aren't options, otherwise override
+			if len(r.Options) == 0 {
+				r.Options = resOpts
+			}
+		}
+		log.Debugf("Create volume -> name: %s, %v", resName, r.Options)
+
+		dest := mountpoint(c.root, resName)
+		if err := createDest(dest); err != nil {
+			return err
+		}
+		c.mountm.Create(resName, dest, r.Options)
+	}
+	return nil
+}
+
+func (c cacheDriver) Remove(r *volume.RemoveRequest) error {
+	c.m.Lock()
+	defer c.m.Unlock()
+	if _, err := strconv.Atoi(r.Name); err == nil {
+		log.Printf("Entering Remove: name: %s", r.Name)
+		if path, ok := c.dirs[r.Name]["Path"]; ok {
+			delete(c.dirs, r.Name)
+			log.Printf("Remove ccache directory: %s", path)
+			os.RemoveAll(path)
+			writeState(c.state, c.dirs)
+		}
+	} else {
+		resolvedName, _ := resolveName(r.Name)
+		log.Debugf("Entering Remove: name: %s, resolved-name: %s", r.Name, resolvedName)
+		if err := c.mountm.Delete(resolvedName); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c cacheDriver) Path(r *volume.PathRequest) (*volume.PathResponse, error) {
+	if _, err := strconv.Atoi(r.Name); err == nil {
+		log.Debugf("Get volume path for: %s", r.Name)
+		if path, ok := c.dirs[r.Name]["Path"]; ok {
+			return &volume.PathResponse{Mountpoint: path}, nil
+		}
+	} else {
+		resolvedName, _ := resolveName(r.Name)
+		log.Debugf("Host path for %s (%s) is at %s", r.Name, resolvedName, mountpoint(c.root, resolvedName))
+		return &volume.PathResponse{Mountpoint: mountpoint(c.root, resolvedName)}, nil
+	}
+	return &volume.PathResponse{Mountpoint: ""}, fmt.Errorf("Can't find volume: %s", r.Name)
+}
+
+func (c cacheDriver) Get(r *volume.GetRequest) (*volume.GetResponse, error) {
+	log.Debugf("Entering Get: %v", r)
+
+	c.m.Lock()
+	defer c.m.Unlock()
+
+	if _, err := strconv.Atoi(r.Name); err == nil {
+		if v, ok := c.dirs[r.Name]; ok {
+			log.Debugf("Get: path found for %s", r.Name)
+			return &volume.GetResponse{
+				Volume: &volume.Volume{
+					Name:       r.Name,
+					Mountpoint: v["Path"],
+				},
+			}, nil
+		}
+	} else {
+		resolvedName, _ := resolveName(r.Name)
+		hostdir := mountpoint(c.root, resolvedName)
+		if c.mountm.HasMount(resolvedName) {
+			log.Debugf("Get: mount found for %s, host directory: %s", resolvedName, hostdir)
+			return &volume.GetResponse{Volume: &volume.Volume{Name: resolvedName, Mountpoint: hostdir}}, nil
+		}
+	}
+	return &volume.GetResponse{}, fmt.Errorf("Can't find volume: %s", r.Name)
+}
+
+func (c cacheDriver) List() (*volume.ListResponse, error) {
+	log.Debugf("Entering List")
+	cachevols := []*volume.Volume{}
+	for k, v := range c.dirs {
+		// Only if path exist list it as volume
+		if _, err := os.Stat(v["Path"]); !os.IsNotExist(err) {
+			cachevols = append(cachevols, &volume.Volume{
+				Name:       k,
+				Mountpoint: v["Path"],
+			})
+		}
+	}
+	volumes := append(cachevols, c.mountm.GetVolumes(c.root)...)
+	return &volume.ListResponse{Volumes: volumes}, nil
+}
+
+func (c cacheDriver) Capabilities() *volume.CapabilitiesResponse {
+	// log.Debugf("Entering Capabilities: %v", r)
+	return &volume.CapabilitiesResponse{
+		Capabilities: volume.Capability{
+			Scope: "local",
+		},
+	}
+}

--- a/netshare/drivers/driver_types.go
+++ b/netshare/drivers/driver_types.go
@@ -5,6 +5,7 @@ type DriverType int
 const (
 	CIFS DriverType = iota
 	NFS
+        NFSCACHE
 	EFS
 	CEPH
 )
@@ -12,6 +13,7 @@ const (
 var driverTypes = []string{
 	"cifs",
 	"nfs",
+        "nfscache",
 	"efs",
 	"ceph",
 }

--- a/netshare/drivers/driver_types.go
+++ b/netshare/drivers/driver_types.go
@@ -5,7 +5,6 @@ type DriverType int
 const (
 	CIFS DriverType = iota
 	NFS
-	NFSCACHE
 	EFS
 	CEPH
 )
@@ -13,7 +12,6 @@ const (
 var driverTypes = []string{
 	"cifs",
 	"nfs",
-	"nfscache",
 	"efs",
 	"ceph",
 }

--- a/netshare/drivers/driver_types.go
+++ b/netshare/drivers/driver_types.go
@@ -5,7 +5,7 @@ type DriverType int
 const (
 	CIFS DriverType = iota
 	NFS
-        NFSCACHE
+	NFSCACHE
 	EFS
 	CEPH
 )
@@ -13,7 +13,7 @@ const (
 var driverTypes = []string{
 	"cifs",
 	"nfs",
-        "nfscache",
+	"nfscache",
 	"efs",
 	"ceph",
 }

--- a/netshare/drivers/mounts.go
+++ b/netshare/drivers/mounts.go
@@ -119,8 +119,8 @@ func (m *MountManager) Delete(name string) error {
 	refCount := checkReferences(name)
 	log.Debugf("Reference count %d", refCount)
 	if m.HasMount(name) {
+		log.Debugf("Delete volume: %s, connections: %d", name, m.Count(name))
 		if m.Count(name) < 1 && refCount < 1 {
-			log.Debugf("Delete volume: %s, connections: %d", name, m.Count(name))
 			delete(m.mounts, name)
 			return nil
 		}
@@ -130,6 +130,7 @@ func (m *MountManager) Delete(name string) error {
 }
 
 func (m *MountManager) DeleteIfNotManaged(name string) error {
+	log.Debugf("Delete Not Managed volume name: %s", name)
 	if m.HasMount(name) && !m.IsActiveMount(name) && !m.mounts[name].managed {
 		log.Infof("Removing un-managed volume")
 		return m.Delete(name)

--- a/netshare/drivers/nfsccache.go
+++ b/netshare/drivers/nfsccache.go
@@ -1,0 +1,203 @@
+package drivers
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/docker/go-plugins-helpers/volume"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	NfsCacheOptions   = "nfsopts"
+	DefaultNfsCacheV3 = "port=2049,nolock,proto=tcp"
+)
+
+type nfsCacheDriver struct {
+	cacheDriver
+	version int
+	nfsopts map[string]string
+	lazyUmount bool
+}
+
+func NewNFSCacheDriver(root string, version int, nfsopts string, mounts *MountManager, path string, state string, lazyUmount bool) nfsCacheDriver {
+	d := nfsCacheDriver{
+		cacheDriver: newCacheDriver(root, mounts, path, state),
+		version:     version,
+		nfsopts:     map[string]string{},
+		lazyUmount:  lazyUmount,
+	}
+
+	if len(nfsopts) > 0 {
+		d.nfsopts[NfsCacheOptions] = nfsopts
+	}
+	return d
+}
+
+func (n nfsCacheDriver) Mount(r *volume.MountRequest) (*volume.MountResponse, error) {
+	log.Debugf("Entering Mount: %v", r)
+
+	n.m.Lock()
+	defer n.m.Unlock()
+
+	if _, err := strconv.Atoi(r.Name); err == nil {
+		if path, ok := n.cacheDriver.dirs[r.Name]["Path"]; ok {
+			log.Printf("Mount volume: %s with mountpoint: %s", r.Name, path)
+			return &volume.MountResponse{Mountpoint: path}, nil
+		}
+	} else {
+		resolvedName, resOpts := resolveName(r.Name)
+
+		hostdir := mountpoint(n.root, resolvedName)
+		source := n.fixSource(resolvedName)
+
+		// Support adhoc mounts (outside of docker volume create)
+		// need to adjust source for ShareOpt
+		if resOpts != nil {
+			if share, found := resOpts[ShareOpt]; found {
+				source = n.fixSource(share)
+			}
+		}
+
+		if n.mountm.HasMount(resolvedName) {
+			log.Infof("Using existing NFS volume mount: %s", hostdir)
+			n.mountm.Increment(resolvedName)
+			regexp1 := "(^|\\s)\\K"
+			regexp2 := "(?=\\s|$)"
+			if err := run(fmt.Sprintf("grep -c -P '%s%s%s' /proc/mounts", regexp1, hostdir, regexp2)); err != nil {
+				log.Infof("Existing NFS volume not mounted, force remount.")
+				// maintain count
+				if n.mountm.Count(resolvedName) > 0 {
+					n.mountm.Decrement(resolvedName)
+				}
+			} else {
+				//n.mountm.Increment(resolvedName)
+				return &volume.MountResponse{Mountpoint: hostdir}, nil
+			}
+		}
+
+		log.Infof("Mounting NFS volume %s on %s", source, hostdir)
+
+		if err := createDest(hostdir); err != nil {
+			if n.mountm.Count(resolvedName) > 0 {
+				n.mountm.Decrement(resolvedName)
+			}
+			return nil, err
+		}
+
+		if n.mountm.HasMount(resolvedName) == false {
+			n.mountm.Create(resolvedName, hostdir, resOpts)
+		}
+
+		n.mountm.Add(resolvedName, hostdir)
+
+		if err := n.mountVolume(resolvedName, source, hostdir, n.version); err != nil {
+			n.mountm.Decrement(resolvedName)
+			return nil, err
+		}
+
+		if n.mountm.GetOption(resolvedName, ShareOpt) != "" && n.mountm.GetOptionAsBool(resolvedName, CreateOpt) {
+			log.Infof("Mount: Share and Create options enabled - using %s as sub-dir mount", resolvedName)
+			datavol := filepath.Join(hostdir, resolvedName)
+			if err := createDest(filepath.Join(hostdir, resolvedName)); err != nil {
+				n.mountm.Decrement(resolvedName)
+				return nil, err
+			}
+			hostdir = datavol
+		}
+
+		return &volume.MountResponse{Mountpoint: hostdir}, nil
+	}
+	return &volume.MountResponse{Mountpoint: ""}, fmt.Errorf("Can't find volume: %s", r.Name)
+}
+
+func (n nfsCacheDriver) Unmount(r *volume.UnmountRequest) error {
+	log.Debugf("Entering Unmount: %v", r)
+
+	n.m.Lock()
+	defer n.m.Unlock()
+
+	if _, err := strconv.Atoi(r.Name); err != nil {
+		resolvedName, _ := resolveName(r.Name)
+
+		hostdir := mountpoint(n.root, resolvedName)
+
+		if n.mountm.HasMount(resolvedName) {
+			if n.mountm.Count(resolvedName) > 1 {
+				log.Printf("Skipping unmount for %s - in use by other containers", resolvedName)
+				n.mountm.Decrement(resolvedName)
+				return nil
+			}
+			n.mountm.Decrement(resolvedName)
+		}
+
+		lazy := ""
+		if n.lazyUmount {
+			lazy = "-l"
+			log.Infof("Unmounting volume name %s from %s with -l", resolvedName, hostdir)
+		} else {
+			log.Infof("Unmounting volume name %s from %s", resolvedName, hostdir)
+		}
+
+		if err := run(fmt.Sprintf("umount %s %s", lazy, hostdir)); err != nil {
+			log.Errorf("Error unmounting volume from host: %s", err.Error())
+			return err
+		}
+
+		n.mountm.DeleteIfNotManaged(resolvedName)
+
+		// Check if directory is empty. This command will return "err" if empty
+		if err := run(fmt.Sprintf("ls -1 %s | grep .", hostdir)); err == nil {
+			log.Warnf("Directory %s not empty after unmount. Skipping RemoveAll call.", hostdir)
+		} else {
+			if err := os.RemoveAll(hostdir); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (n nfsCacheDriver) fixSource(name string) string {
+	if n.mountm.HasOption(name, ShareOpt) {
+		return addShareColon(n.mountm.GetOption(name, ShareOpt))
+	}
+	return addShareColon(name)
+}
+
+func (n nfsCacheDriver) mountVolume(name, source, dest string, version int) error {
+	var cmd string
+
+	options := merge(n.mountm.GetOptions(name), n.nfsopts)
+	opts := ""
+	if val, ok := options[NfsCacheOptions]; ok {
+		opts = val
+	}
+
+	mountCmd := "mount"
+
+	if log.GetLevel() == log.DebugLevel {
+		mountCmd = mountCmd + " -v"
+	}
+
+	switch version {
+	case 3:
+		log.Debugf("Mounting with NFSv3 - src: %s, dest: %s", source, dest)
+		if len(opts) < 1 {
+			opts = DefaultNfsCacheV3
+		}
+		cmd = fmt.Sprintf("%s -t nfs -o %s %s %s", mountCmd, opts, source, dest)
+	default:
+		log.Debugf("Mounting with NFSv4 - src: %s, dest: %s", source, dest)
+		if len(opts) > 0 {
+			cmd = fmt.Sprintf("%s -t nfs4 -o %s %s %s", mountCmd, opts, source, dest)
+		} else {
+			cmd = fmt.Sprintf("%s -t nfs4 %s %s", mountCmd, source, dest)
+		}
+	}
+	log.Debugf("exec: %s\n", cmd)
+	return run(cmd)
+}


### PR DESCRIPTION
* Add NFSCACHE driver
* Add support in NFSCACHE driver to create /tmp/<uuid> directories to run kerberos in docker as user
* Add parameter lazyumount to pass --lazy to the umount command in NFSCACHE driver
* Fix mount grep for similar mounts names
